### PR TITLE
Feat(Permission): Add global Role AND Permission

### DIFF
--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/converter/CustomJwtAuthenticationConverter.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/converter/CustomJwtAuthenticationConverter.java
@@ -21,13 +21,8 @@ public class CustomJwtAuthenticationConverter implements Converter<Jwt, Abstract
 
 	@Override
 	public AbstractAuthenticationToken convert(Jwt jwt) {
-		System.out.println("jwt token : " + jwt.getSubject());
-
 		UUID memberId = UUID.fromString(jwt.getSubject());
 		Member member = memberService.getById(memberId);
-
-		System.out.println("member id : " + memberId);
-		System.out.println("member name : " + member.getName());
 
 		CustomOAuth2User oAuth2User = CustomOAuth2User.from(member, null);
 

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/dto/TokenType.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/dto/TokenType.java
@@ -1,5 +1,0 @@
-package kr.co.jeelee.kiwee.domain.auth.dto;
-
-public enum TokenType {
-	ACCESS, REFRESH
-}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/model/TokenType.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/model/TokenType.java
@@ -1,0 +1,5 @@
+package kr.co.jeelee.kiwee.domain.auth.model;
+
+public enum TokenType {
+	ACCESS, REFRESH
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/oauth/user/CustomOAuth2User.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/oauth/user/CustomOAuth2User.java
@@ -1,8 +1,8 @@
 package kr.co.jeelee.kiwee.domain.auth.oauth.user;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -24,7 +24,10 @@ public record CustomOAuth2User(
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+		return member.getRoles().stream()
+			.flatMap(role -> role.getPermissions().stream())
+			.map(permission -> new SimpleGrantedAuthority(permission.getName().name()))
+			.collect(Collectors.toSet());
 	}
 
 	@Override

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/repository/MemberPlatformRepository.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/repository/MemberPlatformRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.co.jeelee.kiwee.domain.auth.entity.MemberPlatform;
 import kr.co.jeelee.kiwee.domain.platform.entity.Platform;
@@ -11,6 +13,18 @@ import kr.co.jeelee.kiwee.domain.platform.entity.Platform;
 public interface MemberPlatformRepository extends JpaRepository<MemberPlatform,Long> {
 
 	@EntityGraph(attributePaths = {"member"})
-	Optional<MemberPlatform> getWithMemberByPlatformAndPlatformUserId(Platform platform, String platformUserId);
+
+
+	@Query("""
+		SELECT mp FROM MemberPlatform mp
+		JOIN FETCH mp.member m
+		LEFT JOIN FETCH m.roles r
+		LEFT JOIN FETCH r.permissions
+		where mp.platform = :platform and mp.platformUserId = :platformUserId
+	""")
+	Optional<MemberPlatform> getWithAll(
+		@Param("platform") Platform platform,
+		@Param("platformUserId") String platformUserId
+	);
 
 }

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/service/JwtServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/service/JwtServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Service;
 
-import kr.co.jeelee.kiwee.domain.auth.dto.TokenType;
+import kr.co.jeelee.kiwee.domain.auth.model.TokenType;
 import kr.co.jeelee.kiwee.domain.auth.dto.response.TokenResponse;
 import kr.co.jeelee.kiwee.domain.auth.exception.InvalidTokenException;
 import kr.co.jeelee.kiwee.domain.auth.exception.UnauthorizationException;

--- a/src/main/java/kr/co/jeelee/kiwee/domain/auth/service/MemberPlatformServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/auth/service/MemberPlatformServiceImpl.java
@@ -35,8 +35,8 @@ public class MemberPlatformServiceImpl implements MemberPlatformService {
 		String email = Optional.ofNullable(oAuth2UserInfo.attributes().get("email"))
 			.map(Object::toString).orElse(null);
 
-		Optional<MemberPlatform> existingMemberPlatform = memberPlatformRepository
-			.getWithMemberByPlatformAndPlatformUserId(platform, oAuth2UserInfo.id());
+		Optional<MemberPlatform> existingMemberPlatform =
+			memberPlatformRepository.getWithAll(platform, oAuth2UserInfo.id());
 
 		if (existingMemberPlatform.isPresent()) {
 			MemberPlatform mp = existingMemberPlatform.get();

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/controller/PermissionController.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/controller/PermissionController.java
@@ -1,0 +1,42 @@
+package kr.co.jeelee.kiwee.domain.authorization.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.PermissionResponse;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.service.PermissionService;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+import lombok.RequiredArgsConstructor;
+
+@PreAuthorize(value = "hasRole('PERMISSION_GRANTER')")
+@RestController
+@RequestMapping(value = "/api/v1/permissions")
+@RequiredArgsConstructor
+@Validated
+public class PermissionController {
+
+	private final PermissionService permissionService;
+
+	@GetMapping(value = "/{domain}")
+	public PagedResponse<PermissionResponse> getDomainPermissions(
+		@PathVariable DomainType domain,
+		@PageableDefault Pageable pageable
+	) {
+		return permissionService.getDomainPermissions(domain, pageable);
+	}
+
+	@GetMapping(value = "/{id}")
+	public PermissionResponse getById(
+		@PathVariable Long id
+	) {
+		return permissionService.getById(id);
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/controller/RolesController.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/controller/RolesController.java
@@ -1,0 +1,55 @@
+package kr.co.jeelee.kiwee.domain.authorization.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import kr.co.jeelee.kiwee.domain.authorization.dto.request.RoleCreateRequest;
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.RoleResponse;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.service.RoleService;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+import lombok.RequiredArgsConstructor;
+
+@PreAuthorize(value = "hasRole('PERMISSION_GRANTER')")
+@RestController
+@RequestMapping(value = "/api/v1/roles")
+@RequiredArgsConstructor
+@Validated
+public class RolesController {
+
+	private final RoleService roleService;
+
+	@PostMapping
+	public RoleResponse createRole(
+		@Valid @RequestBody RoleCreateRequest request
+	) {
+		return roleService.createRole(request);
+	}
+
+	@GetMapping(value = "/{domain}")
+	public PagedResponse<RoleResponse> getRoles(
+		@PathVariable DomainType domain,
+		@PageableDefault Pageable pageable
+	) {
+		return roleService.getRoles(domain, pageable);
+	}
+
+	@GetMapping(value = "/{id}")
+	public RoleResponse getById(
+		@PathVariable UUID id
+	) {
+		return roleService.getById(id);
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/converter/DomainTypeConverter.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/converter/DomainTypeConverter.java
@@ -1,0 +1,13 @@
+package kr.co.jeelee.kiwee.domain.authorization.converter;
+
+import jakarta.persistence.Converter;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.global.converter.EnumToStringConverter;
+
+@Converter(autoApply = true)
+public class DomainTypeConverter extends EnumToStringConverter<DomainType> {
+
+	public DomainTypeConverter() {
+		super(DomainType.class);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/converter/PermissionTypeConverter.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/converter/PermissionTypeConverter.java
@@ -1,0 +1,13 @@
+package kr.co.jeelee.kiwee.domain.authorization.converter;
+
+import jakarta.persistence.Converter;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+import kr.co.jeelee.kiwee.global.converter.EnumToStringConverter;
+
+@Converter(autoApply = true)
+public class PermissionTypeConverter extends EnumToStringConverter<PermissionType> {
+
+	public PermissionTypeConverter() {
+		super(PermissionType.class);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/request/RoleCreateRequest.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/request/RoleCreateRequest.java
@@ -1,0 +1,15 @@
+package kr.co.jeelee.kiwee.domain.authorization.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+
+public record RoleCreateRequest(
+	@NotBlank(message = "name can't be Blank.") String name,
+	@NotBlank(message = "domain can't be Blank.") DomainType domain,
+	String color,
+	String description,
+	List<Long> permissionId
+) {
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/response/PermissionResponse.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/response/PermissionResponse.java
@@ -1,0 +1,16 @@
+package kr.co.jeelee.kiwee.domain.authorization.dto.response;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Permission;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+
+public record PermissionResponse(
+	Long id, PermissionType name, String description
+) {
+	public static PermissionResponse from(Permission permission) {
+		return new PermissionResponse(
+			permission.getId(),
+			permission.getName(),
+			permission.getDescription()
+		);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/response/RoleResponse.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/dto/response/RoleResponse.java
@@ -1,0 +1,25 @@
+package kr.co.jeelee.kiwee.domain.authorization.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+
+public record RoleResponse(
+	UUID id, DomainType domain, String name, String color,
+	String description, List<PermissionResponse> permissions
+) {
+	public static RoleResponse from(Role role) {
+		return new RoleResponse(
+			role.getId(),
+			role.getDomain(),
+			role.getName(),
+			role.getColor(),
+			role.getDescription(),
+			role.getPermissions().stream()
+				.map(PermissionResponse::from)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/entity/Permission.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/entity/Permission.java
@@ -1,0 +1,47 @@
+package kr.co.jeelee.kiwee.domain.authorization.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+import kr.co.jeelee.kiwee.global.entity.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "permissions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class Permission extends BaseTimeEntity {
+
+	@EqualsAndHashCode.Include
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 30, nullable = false)
+	private DomainType domain;
+
+	@Column(length = 30, unique = true, nullable = false)
+	private PermissionType name;
+
+	@Column
+	private String description;
+
+	private Permission(DomainType domain, PermissionType name, String description) {
+		this.domain = domain;
+		this.name = name;
+		this.description = description;
+	}
+
+	public static Permission of(DomainType domain, PermissionType name, String description) {
+		return new Permission(domain, name, description);
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/entity/Role.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/entity/Role.java
@@ -1,0 +1,74 @@
+package kr.co.jeelee.kiwee.domain.authorization.entity;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.global.entity.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class Role extends BaseTimeEntity {
+
+	@EqualsAndHashCode.Include
+	@Id @GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(length = 30, nullable = false)
+	private DomainType domain;
+
+	@Column(length = 30, unique = true, nullable = false)
+	private String name;
+
+	@Column(length = 8, nullable = false)
+	private String color;
+
+	@Column
+	private String description;
+
+	@ManyToMany
+	@JoinTable(
+		name = "role_permissions",
+		joinColumns = @JoinColumn(name = "role_id"),
+		inverseJoinColumns = @JoinColumn(name = "permission_id")
+	)
+	private Set<Permission> permissions;
+
+	private Role(String name, DomainType domain, String color, String description) {
+		this.name = name;
+		this.domain = domain;
+		this.color = color;
+		this.description = description;
+		this.permissions = new HashSet<>();
+	}
+
+	public static Role of(String name, DomainType domain, String color, String description) {
+		return new Role(name, domain, color, description);
+	}
+
+	public void addPermission(Permission permission) {
+		this.permissions.add(permission);
+	}
+
+	public void removePermission(Permission permission) {
+		this.permissions.remove(permission);
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/exception/PermissionNotFoundException.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/exception/PermissionNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.co.jeelee.kiwee.domain.authorization.exception;
+
+import kr.co.jeelee.kiwee.global.exception.custom.CustomException;
+import kr.co.jeelee.kiwee.global.exception.custom.ErrorCode;
+
+public class PermissionNotFoundException extends CustomException {
+
+	public PermissionNotFoundException() {
+		super(ErrorCode.PERMISSION_NOT_FOUND);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/exception/RoleNotFoundException.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/exception/RoleNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.co.jeelee.kiwee.domain.authorization.exception;
+
+import kr.co.jeelee.kiwee.global.exception.custom.CustomException;
+import kr.co.jeelee.kiwee.global.exception.custom.ErrorCode;
+
+public class RoleNotFoundException extends CustomException {
+
+	public RoleNotFoundException() {
+		super(ErrorCode.ROLE_NOT_FOUND);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/DomainType.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/DomainType.java
@@ -1,0 +1,28 @@
+package kr.co.jeelee.kiwee.domain.authorization.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DomainType {
+	GLOBAL("글로벌"),
+	PLATFORM("플랫폼"),
+	;
+
+	private final String label;
+
+	@JsonCreator
+	public static DomainType from(String name) {
+		return DomainType.valueOf(name.toUpperCase());
+	}
+
+	@JsonValue
+	public String toJson() {
+		return name().toLowerCase();
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/PermissionType.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/PermissionType.java
@@ -1,0 +1,42 @@
+package kr.co.jeelee.kiwee.domain.authorization.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PermissionType {
+	// Global
+	ROLE_PERMISSION_GRANTER(DomainType.GLOBAL, "유저 권한 관리"),
+
+	ROLE_CREATE_MEMBER(DomainType.GLOBAL, "다른 유저 생성"),
+	ROLE_READ_MEMBER(DomainType.GLOBAL, "다른 유저 읽기"),
+	ROLE_EDIT_MEMBER(DomainType.GLOBAL, "다른 유저 수정"),
+	ROLE_DELETE_MEMBER(DomainType.GLOBAL, "다른 유저 삭제"),
+
+	ROLE_CREATE_REPUTATION(DomainType.GLOBAL, "인기 투표 가능"),
+	ROLE_READ_OTHER_REPUTATION(DomainType.GLOBAL, "다른 사람의 인기투표 기록 확인 가능"),
+
+	// Platform
+	ROLE_CREATE_PLATFORM(DomainType.PLATFORM, "플랫폼 생성"),
+	ROLE_EDIT_PLATFORM(DomainType.PLATFORM, "플랫폼 수정"),
+	ROLE_DELETE_PLATFORM(DomainType.PLATFORM, "플랫폼 삭제"),
+	;
+
+	private final DomainType domainType;
+	private final String description;
+
+	@JsonCreator
+	public static PermissionType from(String name) {
+		return PermissionType.valueOf(name.toUpperCase());
+	}
+
+	@JsonValue
+	public String toJson() {
+		return name().toLowerCase();
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/RoleType.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/model/RoleType.java
@@ -1,0 +1,45 @@
+package kr.co.jeelee.kiwee.domain.authorization.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleType {
+	ADMIN("FF0034", DomainType.GLOBAL,"관리자", List.of(PermissionType.values())),
+	MEMBER("EFD141", DomainType.GLOBAL,"맴버", List.of(PermissionType.ROLE_CREATE_REPUTATION)),
+	BOT("5788F6", DomainType.GLOBAL,"봇", List.of(
+		PermissionType.ROLE_CREATE_MEMBER, PermissionType.ROLE_EDIT_MEMBER,
+		PermissionType.ROLE_CREATE_PLATFORM, PermissionType.ROLE_EDIT_PLATFORM,
+		PermissionType.ROLE_READ_MEMBER, PermissionType.ROLE_READ_OTHER_REPUTATION
+	)),
+
+	ANALYST("9D67F0", DomainType.GLOBAL,"상대 인기도 기록 볼 수 있음", List.of(PermissionType.ROLE_READ_OTHER_REPUTATION)),
+
+	PLATFORM_CREATOR("38CF4C",DomainType.PLATFORM, "플랫폼 생성 가능", List.of(PermissionType.ROLE_CREATE_PLATFORM)),
+	PLATFORM_MODERATOR("B3706E", DomainType.PLATFORM,"플랫폼 수정 및 삭제 가능", List.of(
+		PermissionType.ROLE_EDIT_PLATFORM, PermissionType.ROLE_DELETE_PLATFORM
+	)),
+	;
+
+	private final String color;
+	private final DomainType domain;
+	private final String description;
+	private final List<PermissionType> permissions;
+
+	@JsonCreator
+	public static RoleType from(String name) {
+		return RoleType.valueOf(name.toUpperCase());
+	}
+
+	@JsonValue
+	public String toJson() {
+		return name().toLowerCase();
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/repository/PermissionRepository.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/repository/PermissionRepository.java
@@ -1,0 +1,19 @@
+package kr.co.jeelee.kiwee.domain.authorization.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Permission;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+
+	Optional<Permission> findByName(PermissionType name);
+
+	Page<Permission> findByDomain(DomainType domain, Pageable pageable);
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/repository/RoleRepository.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/repository/RoleRepository.java
@@ -1,0 +1,23 @@
+package kr.co.jeelee.kiwee.domain.authorization.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+	boolean existsByName(String name);
+
+	Optional<Role> findByName(String name);
+
+	Optional<Role> getWithPermissionsByName(String name);
+
+	Page<Role> findByDomain(DomainType domain, Pageable pageable);
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/PermissionService.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/PermissionService.java
@@ -1,0 +1,14 @@
+package kr.co.jeelee.kiwee.domain.authorization.service;
+
+import org.springframework.data.domain.Pageable;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.PermissionResponse;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+
+public interface PermissionService {
+
+	PagedResponse<PermissionResponse> getDomainPermissions(DomainType domain, Pageable pageable);
+	PermissionResponse getById(Long id);
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/PermissionServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/PermissionServiceImpl.java
@@ -1,0 +1,32 @@
+package kr.co.jeelee.kiwee.domain.authorization.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.PermissionResponse;
+import kr.co.jeelee.kiwee.domain.authorization.exception.PermissionNotFoundException;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.repository.PermissionRepository;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PermissionServiceImpl implements PermissionService {
+
+	private final PermissionRepository permissionRepository;
+
+	@Override
+	public PagedResponse<PermissionResponse> getDomainPermissions(DomainType domain, Pageable pageable) {
+		return PagedResponse.of(permissionRepository.findByDomain(domain, pageable), PermissionResponse::from);
+	}
+
+	@Override
+	public PermissionResponse getById(Long id) {
+		return permissionRepository.findById(id)
+			.map(PermissionResponse::from)
+			.orElseThrow(PermissionNotFoundException::new);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/RoleService.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/RoleService.java
@@ -1,0 +1,21 @@
+package kr.co.jeelee.kiwee.domain.authorization.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.request.RoleCreateRequest;
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.RoleResponse;
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+
+public interface RoleService {
+
+	PagedResponse<RoleResponse> getRoles(DomainType domain, Pageable pageable);
+	RoleResponse createRole(RoleCreateRequest request);
+	RoleResponse getById(UUID id);
+
+	Role findByName(String name);
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/RoleServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/authorization/service/RoleServiceImpl.java
@@ -1,0 +1,60 @@
+package kr.co.jeelee.kiwee.domain.authorization.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.request.RoleCreateRequest;
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.RoleResponse;
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
+import kr.co.jeelee.kiwee.domain.authorization.exception.RoleNotFoundException;
+import kr.co.jeelee.kiwee.domain.authorization.model.DomainType;
+import kr.co.jeelee.kiwee.domain.authorization.repository.RoleRepository;
+import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+import kr.co.jeelee.kiwee.global.exception.common.FieldValidationException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoleServiceImpl implements RoleService {
+
+	private final RoleRepository roleRepository;
+
+	@Override
+	public PagedResponse<RoleResponse> getRoles(DomainType domain, Pageable pageable) {
+		return PagedResponse.of(roleRepository.findByDomain(domain, pageable), RoleResponse::from);
+	}
+
+	@Override
+	public RoleResponse createRole(RoleCreateRequest request) {
+
+		Role role = Role.of(
+			request.name(),
+			request.domain(),
+			request.color(),
+			request.description()
+		);
+
+		if (roleRepository.existsByName(request.name())) {
+			throw new FieldValidationException("name", "이미 있는 역할입니다.");
+		}
+
+		return RoleResponse.from(roleRepository.save(role));
+	}
+
+	@Override
+	public RoleResponse getById(UUID id) {
+		return roleRepository.findById(id)
+			.map(RoleResponse::from)
+			.orElseThrow(RoleNotFoundException::new);
+	}
+
+	@Override
+	public Role findByName(String name) {
+		return roleRepository.getWithPermissionsByName(name)
+			.orElseThrow(RoleNotFoundException::new);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/controller/MemberController.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,11 +22,14 @@ import jakarta.validation.Valid;
 import kr.co.jeelee.kiwee.domain.auth.oauth.user.CustomOAuth2User;
 import kr.co.jeelee.kiwee.domain.member.dto.request.GainExpRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.request.MemberCreateRequest;
+import kr.co.jeelee.kiwee.domain.member.dto.request.MemberRolesRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.request.UpdateMemberRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.response.MemberDetailResponse;
+import kr.co.jeelee.kiwee.domain.member.dto.response.MemberRolesResponse;
 import kr.co.jeelee.kiwee.domain.member.dto.response.MemberSimpleResponse;
 import kr.co.jeelee.kiwee.domain.member.service.MemberService;
 import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
+import kr.co.jeelee.kiwee.global.exception.common.InvalidParameterException;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -36,6 +40,7 @@ public class MemberController {
 
 	private final MemberService memberService;
 
+	@PreAuthorize(value = "hasRole('CREATE_MEMBER')")
 	@PostMapping
 	public MemberDetailResponse createMember(
 		@Valid @RequestBody MemberCreateRequest memberCreateRequest
@@ -60,11 +65,24 @@ public class MemberController {
 		return memberService.getMemberById(id);
 	}
 
-	@GetMapping(value = "/me")
-	public MemberDetailResponse getMe(@AuthenticationPrincipal CustomOAuth2User principal) {
-		return MemberDetailResponse.from(principal.member());
+	@PreAuthorize(value = "hasRole('PERMISSION_GRANTER')")
+	@GetMapping(value = "/{id}/roles")
+	public MemberRolesResponse getMemberRoles(
+		@PathVariable UUID id
+	) {
+		return memberService.getMemberRoles(id);
 	}
 
+	@PreAuthorize(value = "hasRole('PERMISSION_GRANTER')")
+	@PostMapping(value = "/{id}/roles")
+	public MemberRolesResponse addMemberRoles(
+		@PathVariable UUID id,
+		@Valid @RequestBody MemberRolesRequest request
+	) {
+		return memberService.addRoles(id, request);
+	}
+
+	@PreAuthorize(value = "hasRole('EDIT_MEMBER')")
 	@PatchMapping(value = "/{id}")
 	public MemberDetailResponse changeEmail(
 		@PathVariable UUID id,
@@ -73,6 +91,7 @@ public class MemberController {
 		return memberService.updateMember(id, request);
 	}
 
+	@PreAuthorize(value = "hasRole('EDIT_MEMBER')")
 	@PatchMapping(value = "/{id}/exp")
 	public MemberDetailResponse gainExp(
 		@PathVariable UUID id,
@@ -81,12 +100,45 @@ public class MemberController {
 		return memberService.gainExp(id, request);
 	}
 
+	@PreAuthorize(value = "hasRole('PERMISSION_GRANTER')")
+	@DeleteMapping(value = "/{id}/roles/{roleName}")
+	public ResponseEntity<Void> deleteMemberRoles(
+		@PathVariable UUID id,
+		@PathVariable String roleName
+	) {
+		if (roleName == null || roleName.trim().isBlank()) {
+			throw new InvalidParameterException("role");
+		}
+		memberService.deleteRole(id, roleName);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PreAuthorize(value = "hasRole('DELETE_MEMBER')")
 	@DeleteMapping(value = "/{id}")
 	public ResponseEntity<Void> deleteMember(
 		@PathVariable UUID id
 	) {
 		memberService.deleteMemberById(id);
 
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping(value = "/me")
+	public MemberDetailResponse getMe(@AuthenticationPrincipal CustomOAuth2User principal) {
+		return MemberDetailResponse.from(principal.member());
+	}
+
+	@PatchMapping(value = "/me")
+	public MemberDetailResponse updateMe(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@Valid @RequestBody UpdateMemberRequest request
+	) {
+		return memberService.updateMember(principal.member().getId(), request);
+	}
+
+	@DeleteMapping(value = "/me")
+	public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal CustomOAuth2User principal) {
+		memberService.deleteMemberById(principal.member().getId());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/request/MemberRolesRequest.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/request/MemberRolesRequest.java
@@ -1,0 +1,10 @@
+package kr.co.jeelee.kiwee.domain.member.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record MemberRolesRequest(
+	@NotEmpty(message = "There must be at least one roles.") List<String> roles
+) {
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/response/MemberDetailResponse.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/response/MemberDetailResponse.java
@@ -6,7 +6,7 @@ import kr.co.jeelee.kiwee.domain.member.entity.Member;
 
 public record MemberDetailResponse(
 	UUID id, String name, String nickname, String email, String avatarUrl,
-	int level, long exp, boolean isBot, boolean isActive
+	int level, long exp, boolean isActive
 ) {
 	public static MemberDetailResponse from(Member member) {
 		return new MemberDetailResponse(
@@ -17,7 +17,6 @@ public record MemberDetailResponse(
 			member.getAvatarUrl(),
 			member.getLevel(),
 			member.getExp(),
-			member.isBot(),
 			member.isActive()
 		);
 	}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/response/MemberRolesResponse.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/dto/response/MemberRolesResponse.java
@@ -1,0 +1,21 @@
+package kr.co.jeelee.kiwee.domain.member.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import kr.co.jeelee.kiwee.domain.authorization.dto.response.RoleResponse;
+import kr.co.jeelee.kiwee.domain.member.entity.Member;
+
+public record MemberRolesResponse(
+	UUID id, String name, List<RoleResponse> roles
+) {
+	public static MemberRolesResponse from(Member member) {
+		return new MemberRolesResponse(
+			member.getId(),
+			member.getName(),
+			member.getRoles().stream()
+				.map(RoleResponse::from)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/entity/Member.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/entity/Member.java
@@ -1,5 +1,7 @@
 package kr.co.jeelee.kiwee.domain.member.entity;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -8,8 +10,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
 import kr.co.jeelee.kiwee.global.exception.common.FieldValidationException;
 import kr.co.jeelee.kiwee.global.entity.BaseTimeEntity;
 import lombok.AccessLevel;
@@ -52,8 +58,13 @@ public class Member extends BaseTimeEntity {
 	@Column
 	private String avatarUrl;
 
-	@Column(nullable = false)
-	private boolean isBot;
+	@ManyToMany
+	@JoinTable(
+		name = "member_roles",
+		joinColumns = @JoinColumn(name = "member_id"),
+		inverseJoinColumns = @JoinColumn(name = "role_id")
+	)
+	private Set<Role> roles;
 
 	@Column(nullable = false)
 	private boolean isActive;
@@ -66,7 +77,7 @@ public class Member extends BaseTimeEntity {
 		this.exp = 0;
 		this.totalExp = 0;
 		this.avatarUrl = avatarUrl;
-		this.isBot = false;
+		this.roles = new HashSet<>();
 		this.isActive = true;
 	}
 
@@ -132,6 +143,14 @@ public class Member extends BaseTimeEntity {
 			this.exp -= levelExp;
 			this.gainExp(0);
 		}
+	}
+
+	public void addRole(Set<Role> role) {
+		this.roles.addAll(role);
+	}
+
+	public void removeRole(Role role) {
+		this.roles.remove(role);
 	}
 
 	private long getLevelExp() {

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/exception/MemberNotHaveRoleException.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/exception/MemberNotHaveRoleException.java
@@ -1,0 +1,13 @@
+package kr.co.jeelee.kiwee.domain.member.exception;
+
+import java.util.Map;
+
+import kr.co.jeelee.kiwee.global.exception.custom.CustomException;
+import kr.co.jeelee.kiwee.global.exception.custom.ErrorCode;
+
+public class MemberNotHaveRoleException extends CustomException {
+
+	public MemberNotHaveRoleException() {
+		super(ErrorCode.MEMBER_NOT_HAVE, Map.of("role", "맴버가 소유하지 않은 역할입니다."));
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/repository/MemberRepository.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/repository/MemberRepository.java
@@ -1,10 +1,13 @@
 package kr.co.jeelee.kiwee.domain.member.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import kr.co.jeelee.kiwee.domain.member.entity.Member;
@@ -16,5 +19,13 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
 
 	Boolean existsByNickname(String nickname);
 	Boolean existsByEmail(String email);
+
+	@Query("""
+		select m from Member m
+		join fetch m.roles r
+		join fetch r.permissions
+		where m.id = :id
+	""")
+	Optional<Member> getWithRolesAndPermissionsById(@Param("id") UUID id);
 
 }

--- a/src/main/java/kr/co/jeelee/kiwee/domain/member/service/MemberService.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/member/service/MemberService.java
@@ -8,8 +8,10 @@ import org.springframework.security.core.Authentication;
 import kr.co.jeelee.kiwee.domain.auth.oauth.dto.OAuth2UserInfo;
 import kr.co.jeelee.kiwee.domain.member.dto.request.GainExpRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.request.MemberCreateRequest;
+import kr.co.jeelee.kiwee.domain.member.dto.request.MemberRolesRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.request.UpdateMemberRequest;
 import kr.co.jeelee.kiwee.domain.member.dto.response.MemberDetailResponse;
+import kr.co.jeelee.kiwee.domain.member.dto.response.MemberRolesResponse;
 import kr.co.jeelee.kiwee.domain.member.dto.response.MemberSimpleResponse;
 import kr.co.jeelee.kiwee.domain.member.entity.Member;
 import kr.co.jeelee.kiwee.global.dto.response.PagedResponse;
@@ -22,11 +24,15 @@ public interface MemberService {
 	PagedResponse<MemberSimpleResponse> searchMembers(String keyword, Pageable pageable);
 
 	MemberDetailResponse getMemberById(UUID id);
+	MemberRolesResponse getMemberRoles(UUID id);
 
 	MemberDetailResponse updateMember(UUID id, UpdateMemberRequest updateMemberRequest);
 	MemberDetailResponse gainExp(UUID id, GainExpRequest request);
 
+	MemberRolesResponse addRoles(UUID id, MemberRolesRequest request);
+
 	void deleteMemberById(UUID id);
+	void deleteRole(UUID id, String RoleName);
 
 	Member createByOAuth(OAuth2UserInfo oAuth2UserInfo);
 

--- a/src/main/java/kr/co/jeelee/kiwee/domain/platform/controller/PlatformController.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/platform/controller/PlatformController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +33,7 @@ public class PlatformController {
 
 	private final PlatformService platformService;
 
+	@PreAuthorize(value = "hasRole('CREATE_PLATFORM')")
 	@PostMapping
 	public PlatformDetailResponse createPlatform(
 		@Valid @RequestBody PlatformCreateRequest request
@@ -56,6 +58,7 @@ public class PlatformController {
 		return platformService.getPlatformById(id);
 	}
 
+	@PreAuthorize(value = "hasRole('EDIT_PLATFORM')")
 	@PatchMapping(value = "/{id}")
 	public PlatformDetailResponse updatePlatform(
 		@PathVariable UUID id,
@@ -64,6 +67,7 @@ public class PlatformController {
 		return platformService.updatePlatform(id, request);
 	}
 
+	@PreAuthorize(value = "hasRole('DELETE_PLATFORM')")
 	@DeleteMapping(value = "/{id}")
 	public ResponseEntity<Void> deletePlatform(
 		@PathVariable UUID id

--- a/src/main/java/kr/co/jeelee/kiwee/domain/platform/entity/Platform.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/platform/entity/Platform.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "platform")
+@Table(name = "platforms")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Platform extends BaseTimeEntity {

--- a/src/main/java/kr/co/jeelee/kiwee/domain/reputations/controller/ReputationsController.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/reputations/controller/ReputationsController.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import kr.co.jeelee.kiwee.domain.auth.oauth.user.CustomOAuth2User;
 import kr.co.jeelee.kiwee.domain.reputations.dto.request.ReputationsCreateRequest;
 import kr.co.jeelee.kiwee.domain.reputations.dto.response.ReputationsStatResponse;
 import kr.co.jeelee.kiwee.domain.reputations.dto.response.ReputationsVoteResponse;
@@ -31,6 +34,7 @@ public class ReputationsController {
 
 	private final ReputationService reputationService;
 
+	@PreAuthorize(value = "hasRole('CREATE_REPUTATION')")
 	@PostMapping
 	public ResponseEntity<Void> vote(
 		@Valid @RequestBody ReputationsCreateRequest request
@@ -52,6 +56,27 @@ public class ReputationsController {
 		return reputationService.getLank(yearMonth, pageable);
 	}
 
+	@GetMapping(value = "/me")
+	public ReputationsStatResponse getStatMe(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@RequestParam(required = false) YearMonth yearMonth
+	) {
+		if (yearMonth == null) {
+			yearMonth = YearMonth.now();
+		}
+
+		return reputationService.getStatByMemberId(principal.member().getId(), yearMonth);
+	}
+
+	@GetMapping(value = "/me/logs")
+	public PagedResponse<ReputationsVoteResponse> getVoteByMe(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@PageableDefault Pageable pageable
+	) {
+		return reputationService.getVotesByMemberId(principal.member().getId(), pageable);
+	}
+
+	@PreAuthorize(value = "hasRole('READ_OTHER_REPUTATION')")
 	@GetMapping(value = "/{id}")
 	public ReputationsStatResponse getStatByMemberId(
 		@PathVariable UUID id,
@@ -64,6 +89,7 @@ public class ReputationsController {
 		return reputationService.getStatByMemberId(id, yearMonth);
 	}
 
+	@PreAuthorize(value = "hasRole('READ_OTHER_REPUTATION')")
 	@GetMapping(value = "/{id}/logs")
 	public PagedResponse<ReputationsVoteResponse> getVotesByMemberId(
 		@PathVariable UUID id,

--- a/src/main/java/kr/co/jeelee/kiwee/domain/reputations/exception/ReputationNotFoundException.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/reputations/exception/ReputationNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.co.jeelee.kiwee.domain.reputations.exception;
+
+import kr.co.jeelee.kiwee.global.exception.custom.CustomException;
+import kr.co.jeelee.kiwee.global.exception.custom.ErrorCode;
+
+public class ReputationNotFoundException extends CustomException {
+
+	public ReputationNotFoundException() {
+		super(ErrorCode.REPUTATION_NOT_FOUND);
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/domain/reputations/service/ReputationServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/reputations/service/ReputationServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.co.jeelee.kiwee.domain.member.dto.response.MemberSimpleResponse;
 import kr.co.jeelee.kiwee.domain.member.entity.Member;
 import kr.co.jeelee.kiwee.domain.member.service.MemberService;
+import kr.co.jeelee.kiwee.domain.reputations.exception.ReputationNotFoundException;
 import kr.co.jeelee.kiwee.domain.reputations.repository.ReputationsRepository;
 import kr.co.jeelee.kiwee.domain.reputations.dto.request.ReputationsCreateRequest;
 import kr.co.jeelee.kiwee.domain.reputations.dto.response.ReputationsStatResponse;
@@ -75,6 +76,7 @@ public class ReputationServiceImpl implements ReputationService {
 	@Override
 	public ReputationsStatResponse getStatByMemberId(UUID id, YearMonth yearMonth) {
 		return reputationsRepository.getStatByMemberIdAndYearMonth(id, yearMonth.toString()).stream()
+			.findFirst()
 			.map(p -> {
 				MemberSimpleResponse memberResponse = new MemberSimpleResponse(
 					p.getId(),
@@ -92,7 +94,7 @@ public class ReputationServiceImpl implements ReputationService {
 					p.getDownVotes(),
 					p.getRank()
 				);
-			}).toList().get(0);
+			}).orElseThrow(ReputationNotFoundException::new);
 	}
 
 	@Override

--- a/src/main/java/kr/co/jeelee/kiwee/global/config/SecurityConfig.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package kr.co.jeelee.kiwee.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -15,6 +16,7 @@ import kr.co.jeelee.kiwee.domain.auth.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/kr/co/jeelee/kiwee/global/converter/EnumToStringConverter.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/converter/EnumToStringConverter.java
@@ -1,0 +1,26 @@
+package kr.co.jeelee.kiwee.global.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.RequiredArgsConstructor;
+
+@Converter
+@RequiredArgsConstructor
+public class EnumToStringConverter<T extends Enum<T>> implements AttributeConverter<T, String> {
+
+	private final Class<T> enumClass;
+
+	@Override
+	public String convertToDatabaseColumn(T t) {
+		return t != null
+			? t.name().toUpperCase()
+			: null;
+	}
+
+	@Override
+	public T convertToEntityAttribute(String s) {
+		return s != null
+			? Enum.valueOf(enumClass, s.toUpperCase())
+			: null;
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/global/exception/common/InvalidParameterException.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/exception/common/InvalidParameterException.java
@@ -1,0 +1,13 @@
+package kr.co.jeelee.kiwee.global.exception.common;
+
+import java.util.Map;
+
+import kr.co.jeelee.kiwee.global.exception.custom.CustomException;
+import kr.co.jeelee.kiwee.global.exception.custom.ErrorCode;
+
+public class InvalidParameterException extends CustomException {
+
+	public InvalidParameterException(String parameterName) {
+		super(ErrorCode.REQUEST_INVALID, Map.of(parameterName, "잘못된 인자값 입니다."));
+	}
+}

--- a/src/main/java/kr/co/jeelee/kiwee/global/exception/custom/ErrorCode.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/exception/custom/ErrorCode.java
@@ -20,9 +20,16 @@ public enum ErrorCode {
 	UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "REQUEST-004", "알 수 없는 오류가 발생했습니다."),
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "해당 유저를 찾을 수 없습니다."),
+	MEMBER_NOT_HAVE(HttpStatus.NOT_FOUND, "MEMBER-002", "해당 맴버가 소유하지 않은 자원입니다."),
+
+	REPUTATION_NOT_FOUND(HttpStatus.NOT_FOUND, "REPUTATION-001", "해당 투표 기록이 없습니다."),
 
 	PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM-001", "해당 플랫폼을 찾을 수 없습니다."),
 	MEMBER_PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM-002", "해당 가입 정보를 찾을 수 없습니다."),
+
+	PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "PERMISSION-001", "해당 권한은 찾을 수 없습니다."),
+
+	ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE-001", "해당 역할은 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/kr/co/jeelee/kiwee/global/initializer/PermissionInitializer.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/initializer/PermissionInitializer.java
@@ -1,0 +1,35 @@
+package kr.co.jeelee.kiwee.global.initializer;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Permission;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+import kr.co.jeelee.kiwee.domain.authorization.repository.PermissionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionInitializer implements ApplicationRunner {
+
+	private final PermissionRepository permissionRepository;
+
+	@Override
+	@Transactional
+	public void run(ApplicationArguments args) throws Exception {
+		for (PermissionType permissionType : PermissionType.values()) {
+			permissionRepository.findByName(permissionType)
+				.orElseGet(() -> permissionRepository.save(
+						Permission.of(
+							permissionType.getDomainType(),
+							permissionType,
+							permissionType.getDescription()
+						)
+					)
+				);
+		}
+	}
+
+}

--- a/src/main/java/kr/co/jeelee/kiwee/global/initializer/RoleInitializer.java
+++ b/src/main/java/kr/co/jeelee/kiwee/global/initializer/RoleInitializer.java
@@ -1,0 +1,53 @@
+package kr.co.jeelee.kiwee.global.initializer;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.jeelee.kiwee.domain.authorization.entity.Permission;
+import kr.co.jeelee.kiwee.domain.authorization.entity.Role;
+import kr.co.jeelee.kiwee.domain.authorization.model.PermissionType;
+import kr.co.jeelee.kiwee.domain.authorization.model.RoleType;
+import kr.co.jeelee.kiwee.domain.authorization.repository.PermissionRepository;
+import kr.co.jeelee.kiwee.domain.authorization.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+
+@Order(2)
+@Component
+@RequiredArgsConstructor
+public class RoleInitializer implements ApplicationRunner {
+
+	private final RoleRepository roleRepository;
+	private final PermissionRepository permissionRepository;
+
+	@Override
+	@Transactional
+	public void run(ApplicationArguments args) throws Exception {
+		for (RoleType roleType : RoleType.values()) {
+			Role role = roleRepository.findByName(roleType.name())
+				.orElseGet(() -> roleRepository.save(
+					Role.of(
+						roleType.name(),
+						roleType.getDomain(),
+						roleType.getColor(),
+						roleType.getDescription()
+					)
+				));
+
+			for (PermissionType permissionType : roleType.getPermissions()) {
+				Permission permission = permissionRepository.findByName(permissionType)
+					.orElseGet(() -> permissionRepository.save(Permission.of(
+						permissionType.getDomainType(),
+						permissionType,
+						permissionType.getDescription()
+						)
+					));
+
+				role.addPermission(permission);
+			}
+			roleRepository.save(role);
+		}
+	}
+}


### PR DESCRIPTION
## Role 및 Permission 추가

- 기본적인 인가를 위해 Permission을 넣었습니다.
  + 고정적인 Permission을 부여하고 해당 Role이 이 권한이 있는지 확인하는 절차가 들어가 있습니다.
  + 이는 추후 다른 도메인에서도 쓸 수 있게 확장성있게 설계하고 있습니다.
  + 또는 Role은 유저가 직접 만들 수 있게끔 설계할 예정입니다.
