### PR TITLE
Fix: contentMember root recreate

### DIFF
--- a/src/main/java/kr/co/jeelee/kiwee/domain/contentMember/repository/ContentMemberRepository.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/contentMember/repository/ContentMemberRepository.java
@@ -20,6 +20,7 @@ import kr.co.jeelee.kiwee.domain.member.entity.Member;
 
 public interface ContentMemberRepository extends JpaRepository<ContentMember, Long> {
 
+	boolean existsByMemberIdAndContentId(UUID memberId, UUID contentId);
 	boolean existsByContent_Parent_IdAndMember_Id(UUID parentId, UUID memberId);
 
 	@Query("""

--- a/src/main/java/kr/co/jeelee/kiwee/domain/contentMember/service/ContentMemberServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/contentMember/service/ContentMemberServiceImpl.java
@@ -198,7 +198,10 @@ public class ContentMemberServiceImpl implements ContentMemberService {
 			.orElseGet(() -> {
 				Content root = contentService.getRootById(content.getId());
 
-				if (root.getId() != content.getId()) {
+				if (
+					root.getId() != content.getId() &&
+					contentMemberRepository.existsByMemberIdAndContentId(member.getId(), content.getId())
+				) {
 					contentMemberRepository.save(
 						ContentMember.of(
 							root,

--- a/src/main/java/kr/co/jeelee/kiwee/domain/reward/service/RewardServiceImpl.java
+++ b/src/main/java/kr/co/jeelee/kiwee/domain/reward/service/RewardServiceImpl.java
@@ -34,6 +34,7 @@ import kr.co.jeelee.kiwee.global.exception.common.AccessDeniedException;
 import kr.co.jeelee.kiwee.global.exception.common.FieldValidationException;
 import kr.co.jeelee.kiwee.global.model.RewardMatchPolicy;
 import kr.co.jeelee.kiwee.global.model.RewardRepeatPolicy;
+import kr.co.jeelee.kiwee.global.model.TermType;
 import kr.co.jeelee.kiwee.global.resolver.DomainObjectResolver;
 import kr.co.jeelee.kiwee.global.util.TermUtil;
 import kr.co.jeelee.kiwee.global.vo.RewardCondition;
@@ -206,7 +207,7 @@ public class RewardServiceImpl implements RewardService {
 		LocalDate lastGetTime =
 			rewardMemberService.getDateByLastGetReward(awardeeId, rewardId);
 
-		LocalDate startTerm = repeatPolicy.getTermType() != null
+		LocalDate startTerm = repeatPolicy.getTermType() != null && repeatPolicy.getTermType() != TermType.NONE
 			? TermUtil.getStartTerm(repeatPolicy.getTermType(), LocalDate.now())
 			: null;
 


### PR DESCRIPTION
- ContentMember root가 있을 때 재생성 방지
- 리워드 TermType.ONCE 일 때 Exception 해결

- 엔드포인트 설계 다시 해야함